### PR TITLE
classname typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ First install it using [Composer](https://getcomposer.org/download):
 
 Then enable it in your application's kernel (e.g. `app/AppKernel.php`):
 
-    new Gnugat\MicroFrameworkBundle\MicroFrameworkBundle()
+    new Gnugat\MicroFrameworkBundle\GnugatMicroFrameworkBundle()
 
 ## Features
 


### PR DESCRIPTION
The full class name is GnugatMicroFrameworkBundle , not MicroFrameworkBundle, as the readme says. 

I'm presuming the lesser evil here is to change the readme to match the code, rather than vice versa?

PS - As a beginner to Symfony (pretty familiar with PHP), I'm really enjoying this bundle. Thanks for it! I look forward to making more contributions in the future.
