### PR TITLE
Added getKernel

### DIFF
--- a/Service/KernelApplication.php
+++ b/Service/KernelApplication.php
@@ -40,7 +40,7 @@ class KernelApplication extends Application
         $this->getDefinition()->addOption(new InputOption('--no-debug', null, InputOption::VALUE_NONE, 'Switches off debug mode.'));
     }
 	
-	/**
+    /**
      * @return KernelInterface
      */
     public function getKernel()

--- a/Service/KernelApplication.php
+++ b/Service/KernelApplication.php
@@ -39,6 +39,14 @@ class KernelApplication extends Application
         $this->getDefinition()->addOption(new InputOption('--env', '-e', InputOption::VALUE_REQUIRED, 'The Environment name.', $kernel->getEnvironment()));
         $this->getDefinition()->addOption(new InputOption('--no-debug', null, InputOption::VALUE_NONE, 'Switches off debug mode.'));
     }
+	
+	/**
+     * @return KernelInterface
+     */
+    public function getKernel()
+    {
+        return $this->kernel;
+    }
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
It's nice to be able to access the kernel if you need access to the container/get parameters.
My use case was, creating a command that needed access to the container: 

``` php
$application = $this->getApplication();
$container = $application->getKernel()->getContainer();
$debug = $container->getParameter('debug');
```
