### PR TITLE
Instead of the OS incompatible rm use Symfony's filesystem class.

### DIFF
--- a/Service/KernelCacheClearer.php
+++ b/Service/KernelCacheClearer.php
@@ -2,6 +2,7 @@
 
 namespace Gnugat\MicroFrameworkBundle\Service;
 
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
 
 /**
@@ -14,6 +15,7 @@ class KernelCacheClearer implements CacheClearerInterface
      */
     public function clear($cacheDir)
     {
-        exec("rm -rf $cacheDir");
+        $filesystem = new Filesystem();
+        $filesystem->remove($cacheDir);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     "require": {
         "php": "^5.5.9|^7.0",
         "symfony/class-loader": "^3.0",
+        "symfony/filesystem": "^3.0",
         "symfony/config": "^3.0",
         "symfony/console": "^3.0",
         "symfony/dependency-injection": "^3.0",


### PR DESCRIPTION
Included the filesystem component as dependency, altough it is already included by the config component.
